### PR TITLE
Small implementation of a host

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ $tmp = array_merge_recursive($tmp, $doc);
 }
 $nodelist = $tmp;
 
-function listmsservers($msservers) {
+function liquidrequest($msservers, $apipage) {
     $getrooms = array('http' =>
         array(
             'method' => 'GET'
@@ -24,18 +24,26 @@ function listmsservers($msservers) {
 
     $context = stream_context_create($getrooms); // creating the context for HTTP GET requests
 
-    $servresults = file_get_contents($msservers . "/rooms", //in this example we're checking for rooms, issue #3
+    $servresults = file_get_contents($msservers . $apipage,
                       False,
                       $context
                    );
 
-    echo $servresults;
+    echo $servresults; //Do whatever you want with the output from here (ex. giving the array another option like file location)
 }
 
-
-foreach($nodelist['fetch'] as $msservers) {
-    listmsservers($msservers); //checking all the servers -- I don't know why, but after the official
-    //SRB2 MS, it attempts to run the function on nothing (file_get_contents())
-    //Perhaps a configuration issue on my part?
+function updateliquid() {
+    $apipages = array(
+        "/rooms",
+        "/versions/18",
+        "/rooms/33/servers" //I'd much rather remove this, once there's a way of parsing room lists
+    );
+    global $nodelist;
+    foreach($nodelist['fetch'] as $msservers) {
+        foreach($apipages as $api2) {
+            liquidrequest($msservers, "$api2"); //checking all the servers/pages
+        }
+    }
 }
+updateliquid()
 ?>


### PR DESCRIPTION
A very small script that pings all the servers in the config.yaml (located in the root of the server, in this scenario), asks for the rooms, and returns a response from each server in a manner that's compatible with SRB2. I'm not sure how rooms with conflicting numbers will be handled, hence issue #3, so I'm hesitating to make any of my own implementation of such without any second opinion. A note is that the output of this PHP file in a browser returns unformatted text (no line breaks)